### PR TITLE
EventAwaiter: upgraded to promise() syntax.

### DIFF
--- a/.poggit.yml
+++ b/.poggit.yml
@@ -9,5 +9,5 @@ projects:
     type: library
     libs:
       - src: SOF3/await-generator/await-generator
-        version: "^3.0.0"
+        version: "^3.1.1"
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -10,4 +10,5 @@ projects:
     libs:
       - src: SOF3/await-generator/await-generator
         version: "^3.1.1"
+        epitope: .random
 ...

--- a/.poggit.yml
+++ b/.poggit.yml
@@ -9,6 +9,6 @@ projects:
     type: library
     libs:
       - src: SOF3/await-generator/await-generator
-        version: "^3.1.1"
+        version: "^3.3.0"
         epitope: .random
 ...

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "Apache-2.0",
 	"require": {
 		"pocketmine/pocketmine-mp": "^4.0.0",
-		"sof3/await-generator": "^3.1.1"
+		"sof3/await-generator": "^3.3.0"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
 	"license": "LGPL-3.0",
 	"require": {
 		"pocketmine/pocketmine-mp": "4.0.0",
-		"sof3/await-generator": "^3.1.0"
+		"sof3/await-generator": "^3.1.1"
 	},
 	"autoload": {
 		"psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
 	"name": "sof3/await-std",
 	"type": "library",
 	"description": "Writing user-friendly PocketMine plugins fluently with await-generator style",
-	"license": "LGPL-3.0",
+	"license": "Apache-2.0",
 	"require": {
 		"pocketmine/pocketmine-mp": "^4.0.0",
 		"sof3/await-generator": "^3.1.1"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
 	"description": "Writing user-friendly PocketMine plugins fluently with await-generator style",
 	"license": "LGPL-3.0",
 	"require": {
-		"pocketmine/pocketmine-mp": "4.0.0",
+		"pocketmine/pocketmine-mp": "^4.0.0",
 		"sof3/await-generator": "^3.1.1"
 	},
 	"autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "85ef45051eff6acb7ec734a8f0fd6c73",
+    "content-hash": "b8a87e2e833ab6447c88c92f9575f004",
     "packages": [
         {
             "name": "adhocore/json-comment",
@@ -123,24 +123,24 @@
         },
         {
             "name": "fgrosse/phpasn1",
-            "version": "v2.3.0",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fgrosse/PHPASN1.git",
-                "reference": "20299033c35f4300eb656e7e8e88cf52d1d6694e"
+                "reference": "eef488991d53e58e60c9554b09b1201ca5ba9296"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/20299033c35f4300eb656e7e8e88cf52d1d6694e",
-                "reference": "20299033c35f4300eb656e7e8e88cf52d1d6694e",
+                "url": "https://api.github.com/repos/fgrosse/PHPASN1/zipball/eef488991d53e58e60c9554b09b1201ca5ba9296",
+                "reference": "eef488991d53e58e60c9554b09b1201ca5ba9296",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": "~7.1.0 || ~7.2.0 || ~7.3.0 || ~7.4.0 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.3",
-                "satooshi/php-coveralls": "~2.0"
+                "php-coveralls/php-coveralls": "~2.0",
+                "phpunit/phpunit": "^6.3 || ^7.0 || ^8.0"
             },
             "suggest": {
                 "ext-bcmath": "BCmath is the fallback extension for big integer calculations",
@@ -192,9 +192,9 @@
             ],
             "support": {
                 "issues": "https://github.com/fgrosse/PHPASN1/issues",
-                "source": "https://github.com/fgrosse/PHPASN1/tree/v2.3.0"
+                "source": "https://github.com/fgrosse/PHPASN1/tree/v2.4.0"
             },
-            "time": "2021-04-24T19:01:55+00:00"
+            "time": "2021-12-11T12:41:06+00:00"
         },
         {
             "name": "netresearch/jsonmapper",
@@ -249,42 +249,42 @@
         },
         {
             "name": "pocketmine/bedrock-data",
-            "version": "1.4.0+bedrock-1.17.40",
+            "version": "1.7.0+bedrock-1.18.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockData.git",
-                "reference": "f29b7be8fa3046d2ee4c6421485b97b3f5b07774"
+                "reference": "c8f323ff0cbdb36a5d95e7e4a23969f562445be0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockData/zipball/f29b7be8fa3046d2ee4c6421485b97b3f5b07774",
-                "reference": "f29b7be8fa3046d2ee4c6421485b97b3f5b07774",
+                "url": "https://api.github.com/repos/pmmp/BedrockData/zipball/c8f323ff0cbdb36a5d95e7e4a23969f562445be0",
+                "reference": "c8f323ff0cbdb36a5d95e7e4a23969f562445be0",
                 "shasum": ""
             },
             "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "LGPL-3.0"
+                "CC0-1.0"
             ],
             "description": "Blobs of data generated from Minecraft: Bedrock Edition, used by PocketMine-MP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockData/issues",
-                "source": "https://github.com/pmmp/BedrockData/tree/bedrock-1.17.40"
+                "source": "https://github.com/pmmp/BedrockData/tree/bedrock-1.18.30"
             },
-            "time": "2021-10-19T16:55:41+00:00"
+            "time": "2022-04-20T12:40:59+00:00"
         },
         {
             "name": "pocketmine/bedrock-protocol",
-            "version": "5.1.3+bedrock-1.17.40",
+            "version": "9.0.1+bedrock-1.18.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BedrockProtocol.git",
-                "reference": "f56aefc60a00d1440e309edb89a8d7e4925fa3bc"
+                "reference": "9d3cc87c4d26c002dd42aa9af20c0cd47a72018e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/f56aefc60a00d1440e309edb89a8d7e4925fa3bc",
-                "reference": "f56aefc60a00d1440e309edb89a8d7e4925fa3bc",
+                "url": "https://api.github.com/repos/pmmp/BedrockProtocol/zipball/9d3cc87c4d26c002dd42aa9af20c0cd47a72018e",
+                "reference": "9d3cc87c4d26c002dd42aa9af20c0cd47a72018e",
                 "shasum": ""
             },
             "require": {
@@ -298,7 +298,7 @@
                 "ramsey/uuid": "^4.1"
             },
             "require-dev": {
-                "phpstan/phpstan": "1.1.1",
+                "phpstan/phpstan": "1.5.7",
                 "phpstan/phpstan-phpunit": "^1.0.0",
                 "phpstan/phpstan-strict-rules": "^1.0.0",
                 "phpunit/phpunit": "^9.5"
@@ -316,22 +316,22 @@
             "description": "An implementation of the Minecraft: Bedrock Edition protocol in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/BedrockProtocol/issues",
-                "source": "https://github.com/pmmp/BedrockProtocol/tree/5.1.3+bedrock-1.17.40"
+                "source": "https://github.com/pmmp/BedrockProtocol/tree/9.0.1+bedrock-1.18.30"
             },
-            "time": "2021-11-14T02:25:53+00:00"
+            "time": "2022-04-23T14:48:16+00:00"
         },
         {
             "name": "pocketmine/binaryutils",
-            "version": "0.2.2",
+            "version": "0.2.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/BinaryUtils.git",
-                "reference": "f883e1cf9099ed6a757a10a2f75b3333eeb2cdf9"
+                "reference": "5ac7eea91afbad8dc498f5ce34ce6297d5e6ea9a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/BinaryUtils/zipball/f883e1cf9099ed6a757a10a2f75b3333eeb2cdf9",
-                "reference": "f883e1cf9099ed6a757a10a2f75b3333eeb2cdf9",
+                "url": "https://api.github.com/repos/pmmp/BinaryUtils/zipball/5ac7eea91afbad8dc498f5ce34ce6297d5e6ea9a",
+                "reference": "5ac7eea91afbad8dc498f5ce34ce6297d5e6ea9a",
                 "shasum": ""
             },
             "require": {
@@ -340,8 +340,10 @@
             },
             "require-dev": {
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.99",
-                "phpstan/phpstan-strict-rules": "^0.12.4"
+                "phpstan/phpstan": "1.3.0",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0.0",
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "autoload": {
@@ -356,9 +358,9 @@
             "description": "Classes and methods for conveniently handling binary data",
             "support": {
                 "issues": "https://github.com/pmmp/BinaryUtils/issues",
-                "source": "https://github.com/pmmp/BinaryUtils/tree/0.2.2"
+                "source": "https://github.com/pmmp/BinaryUtils/tree/0.2.4"
             },
-            "time": "2021-10-22T19:54:16+00:00"
+            "time": "2022-01-12T18:06:33+00:00"
         },
         {
             "name": "pocketmine/callback-validator",
@@ -495,24 +497,25 @@
         },
         {
             "name": "pocketmine/errorhandler",
-            "version": "0.3.0",
+            "version": "0.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/ErrorHandler.git",
-                "reference": "ec742b209e8056bbe855069c4eff94c9734ea19b"
+                "reference": "dae214a04348b911e8219ebf125ff1c5589cc878"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/ErrorHandler/zipball/ec742b209e8056bbe855069c4eff94c9734ea19b",
-                "reference": "ec742b209e8056bbe855069c4eff94c9734ea19b",
+                "url": "https://api.github.com/repos/pmmp/ErrorHandler/zipball/dae214a04348b911e8219ebf125ff1c5589cc878",
+                "reference": "dae214a04348b911e8219ebf125ff1c5589cc878",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "0.12.75",
-                "phpstan/phpstan-strict-rules": "^0.12.2"
+                "phpstan/phpstan": "0.12.99",
+                "phpstan/phpstan-strict-rules": "^0.12.2",
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "autoload": {
@@ -527,22 +530,22 @@
             "description": "Utilities to handle nasty PHP E_* errors in a usable way",
             "support": {
                 "issues": "https://github.com/pmmp/ErrorHandler/issues",
-                "source": "https://github.com/pmmp/ErrorHandler/tree/0.3.0"
+                "source": "https://github.com/pmmp/ErrorHandler/tree/0.6.0"
             },
-            "time": "2021-02-12T18:56:22+00:00"
+            "time": "2022-01-08T21:05:46+00:00"
         },
         {
             "name": "pocketmine/locale-data",
-            "version": "1.1.6",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/Language.git",
-                "reference": "216b49b87e20332f0b39d1717e1e2012a40074cc"
+                "reference": "df6fc7f2b48850b306c60466a11f7a27bb8fe1de"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/Language/zipball/216b49b87e20332f0b39d1717e1e2012a40074cc",
-                "reference": "216b49b87e20332f0b39d1717e1e2012a40074cc",
+                "url": "https://api.github.com/repos/pmmp/Language/zipball/df6fc7f2b48850b306c60466a11f7a27bb8fe1de",
+                "reference": "df6fc7f2b48850b306c60466a11f7a27bb8fe1de",
                 "shasum": ""
             },
             "type": "library",
@@ -550,9 +553,9 @@
             "description": "Language resources used by PocketMine-MP",
             "support": {
                 "issues": "https://github.com/pmmp/Language/issues",
-                "source": "https://github.com/pmmp/Language/tree/1.1.6"
+                "source": "https://github.com/pmmp/Language/tree/2.5.0"
             },
-            "time": "2021-11-07T14:30:46+00:00"
+            "time": "2022-04-01T22:36:58+00:00"
         },
         {
             "name": "pocketmine/log",
@@ -641,16 +644,16 @@
         },
         {
             "name": "pocketmine/math",
-            "version": "0.4.0",
+            "version": "0.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/Math.git",
-                "reference": "6d64e2555bd2e95ed024574f75d1cefc135c89fc"
+                "reference": "aacc3759a508a69dfa5bc4dfa770ab733c5c94bf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/Math/zipball/6d64e2555bd2e95ed024574f75d1cefc135c89fc",
-                "reference": "6d64e2555bd2e95ed024574f75d1cefc135c89fc",
+                "url": "https://api.github.com/repos/pmmp/Math/zipball/aacc3759a508a69dfa5bc4dfa770ab733c5c94bf",
+                "reference": "aacc3759a508a69dfa5bc4dfa770ab733c5c94bf",
                 "shasum": ""
             },
             "require": {
@@ -658,10 +661,10 @@
                 "php-64bit": "*"
             },
             "require-dev": {
-                "irstea/phpunit-shim": "^8.5 || ^9.5",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.99",
-                "phpstan/phpstan-strict-rules": "^0.12.4"
+                "phpstan/phpstan": "1.2.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^8.5 || ^9.5"
             },
             "type": "library",
             "autoload": {
@@ -676,22 +679,22 @@
             "description": "PHP library containing math related code used in PocketMine-MP",
             "support": {
                 "issues": "https://github.com/pmmp/Math/issues",
-                "source": "https://github.com/pmmp/Math/tree/0.4.0"
+                "source": "https://github.com/pmmp/Math/tree/0.4.2"
             },
-            "time": "2021-10-29T20:33:10+00:00"
+            "time": "2021-12-05T01:15:17+00:00"
         },
         {
             "name": "pocketmine/nbt",
-            "version": "0.3.0",
+            "version": "0.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/NBT.git",
-                "reference": "98c4a04b55a915e18f83d3b0c9beb24a71abcd31"
+                "reference": "3e0d9ef6b6c5fb45e3745a121296e75631b3eefe"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/NBT/zipball/98c4a04b55a915e18f83d3b0c9beb24a71abcd31",
-                "reference": "98c4a04b55a915e18f83d3b0c9beb24a71abcd31",
+                "url": "https://api.github.com/repos/pmmp/NBT/zipball/3e0d9ef6b6c5fb45e3745a121296e75631b3eefe",
+                "reference": "3e0d9ef6b6c5fb45e3745a121296e75631b3eefe",
                 "shasum": ""
             },
             "require": {
@@ -700,10 +703,10 @@
                 "pocketmine/binaryutils": "^0.2.0"
             },
             "require-dev": {
-                "irstea/phpunit-shim": "^9.5",
                 "phpstan/extension-installer": "^1.0",
-                "phpstan/phpstan": "0.12.85",
-                "phpstan/phpstan-strict-rules": "^0.12.4"
+                "phpstan/phpstan": "1.2.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
             },
             "type": "library",
             "autoload": {
@@ -718,28 +721,28 @@
             "description": "PHP library for working with Named Binary Tags",
             "support": {
                 "issues": "https://github.com/pmmp/NBT/issues",
-                "source": "https://github.com/pmmp/NBT/tree/0.3.0"
+                "source": "https://github.com/pmmp/NBT/tree/0.3.2"
             },
-            "time": "2021-05-18T15:46:33+00:00"
+            "time": "2021-12-16T01:02:37+00:00"
         },
         {
             "name": "pocketmine/pocketmine-mp",
-            "version": "4.0.0-BETA12",
+            "version": "4.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/PocketMine-MP.git",
-                "reference": "635a9143de62e69c6811ef4bc9cb65933b166cd7"
+                "reference": "7bbb2617c8b0af24ffd6df86041e487eed9fb889"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/PocketMine-MP/zipball/635a9143de62e69c6811ef4bc9cb65933b166cd7",
-                "reference": "635a9143de62e69c6811ef4bc9cb65933b166cd7",
+                "url": "https://api.github.com/repos/pmmp/PocketMine-MP/zipball/7bbb2617c8b0af24ffd6df86041e487eed9fb889",
+                "reference": "7bbb2617c8b0af24ffd6df86041e487eed9fb889",
                 "shasum": ""
             },
             "require": {
                 "adhocore/json-comment": "^1.1",
                 "composer-runtime-api": "^2.0",
-                "ext-chunkutils2": "^0.3.0",
+                "ext-chunkutils2": "^0.3.1",
                 "ext-crypto": "^0.3.1",
                 "ext-ctype": "*",
                 "ext-curl": "*",
@@ -766,18 +769,18 @@
                 "netresearch/jsonmapper": "^4.0",
                 "php": "^8.0",
                 "php-64bit": "*",
-                "pocketmine/bedrock-data": "^1.4.0+bedrock-1.17.40",
-                "pocketmine/bedrock-protocol": "^5.0.0+bedrock-1.17.40",
+                "pocketmine/bedrock-data": "~1.7.0+bedrock-1.18.30",
+                "pocketmine/bedrock-protocol": "~9.0.0+bedrock-1.18.30",
                 "pocketmine/binaryutils": "^0.2.1",
                 "pocketmine/callback-validator": "^1.0.2",
                 "pocketmine/classloader": "^0.2.0",
                 "pocketmine/color": "^0.2.0",
-                "pocketmine/errorhandler": "^0.3.0",
-                "pocketmine/locale-data": "^1.1.4",
+                "pocketmine/errorhandler": "^0.6.0",
+                "pocketmine/locale-data": "~2.5.0",
                 "pocketmine/log": "^0.4.0",
                 "pocketmine/log-pthreads": "^0.4.0",
                 "pocketmine/math": "^0.4.0",
-                "pocketmine/nbt": "^0.3.0",
+                "pocketmine/nbt": "^0.3.2",
                 "pocketmine/raklib": "^0.14.2",
                 "pocketmine/raklib-ipc": "^0.1.0",
                 "pocketmine/snooze": "^0.3.0",
@@ -785,19 +788,19 @@
                 "webmozart/path-util": "^2.3"
             },
             "require-dev": {
-                "phpstan/phpstan": "1.1.1",
-                "phpstan/phpstan-phpunit": "^1.0.0",
-                "phpstan/phpstan-strict-rules": "^1.0.0",
+                "phpstan/phpstan": "1.6.8",
+                "phpstan/phpstan-phpunit": "^1.1.0",
+                "phpstan/phpstan-strict-rules": "^1.2.0",
                 "phpunit/phpunit": "^9.2"
             },
             "type": "project",
             "autoload": {
-                "psr-4": {
-                    "pocketmine\\": "src/"
-                },
                 "files": [
                     "src/CoreConstants.php"
-                ]
+                ],
+                "psr-4": {
+                    "pocketmine\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -807,7 +810,7 @@
             "homepage": "https://pmmp.io",
             "support": {
                 "issues": "https://github.com/pmmp/PocketMine-MP/issues",
-                "source": "https://github.com/pmmp/PocketMine-MP/tree/4.0.0-BETA12"
+                "source": "https://github.com/pmmp/PocketMine-MP/tree/4.3.4"
             },
             "funding": [
                 {
@@ -819,20 +822,20 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-11-09T16:50:42+00:00"
+            "time": "2022-05-22T15:12:12+00:00"
         },
         {
             "name": "pocketmine/raklib",
-            "version": "0.14.2",
+            "version": "0.14.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pmmp/RakLib.git",
-                "reference": "e3a861187470e1facc6625040128f447ebbcbaec"
+                "reference": "1ea8e3b95a1b6bf785dc27d76578657be4185f42"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pmmp/RakLib/zipball/e3a861187470e1facc6625040128f447ebbcbaec",
-                "reference": "e3a861187470e1facc6625040128f447ebbcbaec",
+                "url": "https://api.github.com/repos/pmmp/RakLib/zipball/1ea8e3b95a1b6bf785dc27d76578657be4185f42",
+                "reference": "1ea8e3b95a1b6bf785dc27d76578657be4185f42",
                 "shasum": ""
             },
             "require": {
@@ -844,8 +847,8 @@
                 "pocketmine/log": "^0.3.0 || ^0.4.0"
             },
             "require-dev": {
-                "phpstan/phpstan": "0.12.99",
-                "phpstan/phpstan-strict-rules": "^0.12.2"
+                "phpstan/phpstan": "1.5.4",
+                "phpstan/phpstan-strict-rules": "^1.0"
             },
             "type": "library",
             "autoload": {
@@ -860,9 +863,9 @@
             "description": "A RakNet server implementation written in PHP",
             "support": {
                 "issues": "https://github.com/pmmp/RakLib/issues",
-                "source": "https://github.com/pmmp/RakLib/tree/0.14.2"
+                "source": "https://github.com/pmmp/RakLib/tree/0.14.4"
             },
-            "time": "2021-10-04T20:39:11+00:00"
+            "time": "2022-04-17T18:42:17+00:00"
         },
         {
             "name": "pocketmine/raklib-ipc",
@@ -1026,25 +1029,24 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.2.3",
+            "version": "4.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df"
+                "reference": "8505afd4fea63b81a85d3b7b53ac3cb8dc347c28"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
-                "reference": "fc9bb7fb5388691fd7373cd44dcb4d63bbcf24df",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8505afd4fea63b81a85d3b7b53ac3cb8dc347c28",
+                "reference": "8505afd4fea63b81a85d3b7b53ac3cb8dc347c28",
                 "shasum": ""
             },
             "require": {
                 "brick/math": "^0.8 || ^0.9",
+                "ext-ctype": "*",
                 "ext-json": "*",
-                "php": "^7.2 || ^8.0",
-                "ramsey/collection": "^1.0",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-php80": "^1.14"
+                "php": "^8.0",
+                "ramsey/collection": "^1.0"
             },
             "replace": {
                 "rhumsaa/uuid": "self.version"
@@ -1081,20 +1083,17 @@
             },
             "type": "library",
             "extra": {
-                "branch-alias": {
-                    "dev-main": "4.x-dev"
-                },
                 "captainhook": {
                     "force-install": true
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Ramsey\\Uuid\\": "src/"
-                },
                 "files": [
                     "src/functions.php"
-                ]
+                ],
+                "psr-4": {
+                    "Ramsey\\Uuid\\": "src/"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1108,7 +1107,7 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.2.3"
+                "source": "https://github.com/ramsey/uuid/tree/4.3.1"
             },
             "funding": [
                 {
@@ -1120,29 +1119,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-09-25T23:10:38+00:00"
+            "time": "2022-03-27T21:42:02+00:00"
         },
         {
             "name": "sof3/await-generator",
-            "version": "3.1.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/SOF3/await-generator.git",
-                "reference": "c7d99f6c5a9338d9215af0f83880c9a11df83ca3"
+                "reference": "9e290d34fd627584d00f0b3105b7335c67ff5494"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/SOF3/await-generator/zipball/c7d99f6c5a9338d9215af0f83880c9a11df83ca3",
-                "reference": "c7d99f6c5a9338d9215af0f83880c9a11df83ca3",
+                "url": "https://api.github.com/repos/SOF3/await-generator/zipball/9e290d34fd627584d00f0b3105b7335c67ff5494",
+                "reference": "9e290d34fd627584d00f0b3105b7335c67ff5494",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^8.0"
             },
             "require-dev": {
                 "composer/package-versions-deprecated": "1.11.99.1",
                 "infection/infection": "^0.18.2 || ^0.20.2",
-                "phpstan/phpstan": "^0.12.20",
+                "phpstan/phpstan": "^0.12.84",
                 "phpunit/phpunit": "^9"
             },
             "type": "library",
@@ -1164,26 +1163,29 @@
             "description": "Use async/await in PHP using generators",
             "support": {
                 "issues": "https://github.com/SOF3/await-generator/issues",
-                "source": "https://github.com/SOF3/await-generator/tree/3.1.0"
+                "source": "https://github.com/SOF3/await-generator/tree/3.4.1"
             },
-            "time": "2021-03-06T06:16:22+00:00"
+            "time": "2022-03-19T09:38:28+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
-                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/30885182c981ab175d4d034db0f6f469898070ab",
+                "reference": "30885182c981ab175d4d034db0f6f469898070ab",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.1"
+            },
+            "provide": {
+                "ext-ctype": "*"
             },
             "suggest": {
                 "ext-ctype": "For best performance"
@@ -1199,12 +1201,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Ctype\\": ""
-                },
                 "files": [
                     "bootstrap.php"
-                ]
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -1229,7 +1231,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1245,103 +1247,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-02-19T12:13:01+00:00"
-        },
-        {
-            "name": "symfony/polyfill-php80",
-            "version": "v1.23.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "reference": "1100343ed1a92e3a38f9ae122fc0eb21602547be",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.1"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "1.23-dev"
-                },
-                "thanks": {
-                    "name": "symfony/polyfill",
-                    "url": "https://github.com/symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php80\\": ""
-                },
-                "files": [
-                    "bootstrap.php"
-                ],
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ion Bazan",
-                    "email": "ion.bazan@gmail.com"
-                },
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.0+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2021-07-28T13:41:28+00:00"
+            "time": "2021-10-20T20:35:02+00:00"
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.23.0",
+            "version": "v1.25.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436"
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/e66119f3de95efc359483f810c4c3e6436279436",
-                "reference": "e66119f3de95efc359483f810c4c3e6436279436",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
+                "reference": "5de4ba2d41b15f9bd0e19b2ab9674135813ec98f",
                 "shasum": ""
             },
             "require": {
@@ -1358,12 +1277,12 @@
                 }
             },
             "autoload": {
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
                 "files": [
                     "bootstrap.php"
                 ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php81\\": ""
+                },
                 "classmap": [
                     "Resources/stubs"
                 ]
@@ -1391,7 +1310,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.23.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.25.0"
             },
             "funding": [
                 {
@@ -1407,7 +1326,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-05-21T13:25:03+00:00"
+            "time": "2021-09-13T13:58:11+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1587,12 +1506,10 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "pocketmine/pocketmine-mp": 10
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/src/SOFe/AwaitStd/Await.php
+++ b/src/SOFe/AwaitStd/Await.php
@@ -2,4 +2,6 @@
 
 namespace SOFe\AwaitStd;
 
-class_alias(\SOFe\AwaitGenerator\Await::class, __NAMESPACE__ . "\\Await");
+use SOFe\AwaitGenerator\Await as Shaded;
+
+class_alias(Shaded::class, __NAMESPACE__ . "\\Await");

--- a/src/SOFe/AwaitStd/AwaitStd.php
+++ b/src/SOFe/AwaitStd/AwaitStd.php
@@ -81,7 +81,7 @@ final class AwaitStd {
 	 */
 	public function timeout(Generator $promise, int $ticks, $onTimeout = null) : Generator {
 		$sleep = $this->sleep($ticks);
-		[$which, $ret] = Await::race([$sleep, $promise]);
+		[$which, $ret] = yield from Await::race([$sleep, $promise]);
 		return match($which) {
 			0 => $onTimeout,
 			1 => $ret,

--- a/src/SOFe/AwaitStd/DisposableListener.php
+++ b/src/SOFe/AwaitStd/DisposableListener.php
@@ -61,7 +61,10 @@ final class DisposableListener {
 		if(!$this->finalizers->contains($disposable)) {
 			$this->finalizers->attach($disposable, []);
 		}
-		$this->finalizers[$disposable][] = $closure;
+
+		$finalizersOfDisposable = $this->finalizers[$disposable] ?? [];
+		$finalizersOfDisposable[] = $closure;
+		$this->finalizers[$disposable] = $finalizersOfDisposable;
 	}
 
 	private function triggerFinalizers(object $object) : void {

--- a/src/SOFe/AwaitStd/EventAwaiter.php
+++ b/src/SOFe/AwaitStd/EventAwaiter.php
@@ -35,9 +35,9 @@ final class EventAwaiter {
 
 		$fail = yield Await::REJECT;
 		foreach($disposables as $disposable) {
-			$this->disposableListener->addFinalizer($disposable, function() use($disposable, $eventClass, $id, $fail) : void {
-				if(isset($this->queues[$eventClass][$id])) {
-					unset($this->queues[$eventClass][$id]);
+			$this->disposableListener->addFinalizer($disposable, function () use ($queueKey, $disposable, $id, $fail) : void {
+				if (isset($this->queues[$queueKey][$id])) {
+					unset($this->queues[$queueKey][$id]);
 					$fail(new DisposeException($this->plugin, $this->disposableListener->getEventDescription($disposable), $disposable));
 				}
 			});

--- a/src/SOFe/AwaitStd/PromiseRejectedException.php
+++ b/src/SOFe/AwaitStd/PromiseRejectedException.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+namespace SOFe\AwaitStd;
+
+use Exception;
+
+final class PromiseRejectedException extends Exception {}


### PR DESCRIPTION
- Fixed a generator not being yielded (AwaitStd.php#L84) (#5)
- Store the disposable's finalizers in a station-variable before modifying
- Virions can't shade fully qualified paths
- Force update await-generator
- Use random epitope for await-generator shading
- Update src/SOFe/AwaitStd/DisposableListener.php
- Fixed using the wrong key when loading from EventAwaiter.php queues
- Fixed pocketmine/pocketmine-mp version in composer.json
- Fixed license in composer manifest
- Add `promiseToGenerator()` to AwaitStd
- EventAwaiter: upgraded to promise() syntax.
